### PR TITLE
Fix #16 + cosmetic changes

### DIFF
--- a/gff3.md
+++ b/gff3.md
@@ -76,7 +76,7 @@ Undefined fields are replaced with the "." character, as described in the origin
             <dd>Indicates the parent of the feature. A parent ID can be used to group exons into transcripts, transcripts into genes, an so forth. A feature may have multiple parents. Parent can <em>only</em> be used to indicate a partof relationship.</dd>
             <dt>Target</dt>
             <dd>Indicates the target of a nucleotide-to-nucleotide or protein-to-nucleotide alignment. The format of the value is "target_id start end [strand]", where strand is optional and may be "+" or "-". If the target_id contains spaces, they must be escaped as hex escape %20.</dd>
-            <dt>[Gap](#the-gap-attribute)</dt>
+            <dt><a href="#the-gap-attribute">Gap</a></dt>
             <dd>The alignment of the feature to the target if the two are not collinear (e.g. contain gaps). The alignment format is inspired from the CIGAR format described in the <a href="https://www.ebi.ac.uk/about/vertebrate-genomics/software/exonerate-manual">Exonerate documentation</a>.</dd>
             <dt>Derives_from</dt>
             <dd>Used to disambiguate the relationship between one feature and another when the relationship is a temporal one rather than a purely structural "part of" one. This is needed for polycistronic genes. See "PATHOLOGICAL CASES" for further discussion.</dd>

--- a/gff3.md
+++ b/gff3.md
@@ -72,7 +72,7 @@ Undefined fields are replaced with the "." character, as described in the origin
             <dd>Display name for the feature. This is the name to be displayed to the user. Unlike IDs, there is no requirement that the Name be unique within the file.</dd>
             <dt>Alias</dt>
             <dd>A secondary name for the feature. It is suggested that this tag be used whenever a secondary identifier for the feature is needed, such as locus names and accession numbers. Unlike ID, there is no requirement that Alias be unique within the file.</dd>
-            <dt>[Parent](#parent-(part_of)-relationships)</dt>
+            <dt><a href="#parent-part_of-relationships">Parent</a></dt>
             <dd>Indicates the parent of the feature. A parent ID can be used to group exons into transcripts, transcripts into genes, an so forth. A feature may have multiple parents. Parent can <em>only</em> be used to indicate a partof relationship.</dd>
             <dt>Target</dt>
             <dd>Indicates the target of a nucleotide-to-nucleotide or protein-to-nucleotide alignment. The format of the value is "target_id start end [strand]", where strand is optional and may be "+" or "-". If the target_id contains spaces, they must be escaped as hex escape %20.</dd>
@@ -82,9 +82,9 @@ Undefined fields are replaced with the "." character, as described in the origin
             <dd>Used to disambiguate the relationship between one feature and another when the relationship is a temporal one rather than a purely structural "part of" one. This is needed for polycistronic genes. See "PATHOLOGICAL CASES" for further discussion.</dd>
             <dt>Note</dt>
             <dd>A free text note.</dd>
-            <dt>[Dbxref](ontology-associations-and-db-cross-references)</dt>
+            <dt><a href="#ontology-associations-and-db-cross-references">Dbxref</a></dt>
             <dd>A database cross reference. See the section "Ontology Associations and Db Cross References" for details on the format.</dd>
-            <dt>[Ontology_term](ontology-associations-and-db-cross-references)</dt>
+            <dt><a href="#ontology-associations-and-db-cross-references">Ontology_term</a></dt>
             <dd>A cross reference to an ontology term. See the section "Ontology Associations and Db Cross References" for details.</dd>
             <dt>Is_circular</dt>
             <dd>A flag to indicate whether a feature is circular. See extended discussion below.</dd>

--- a/gff3.md
+++ b/gff3.md
@@ -72,19 +72,19 @@ Undefined fields are replaced with the "." character, as described in the origin
             <dd>Display name for the feature. This is the name to be displayed to the user. Unlike IDs, there is no requirement that the Name be unique within the file.</dd>
             <dt>Alias</dt>
             <dd>A secondary name for the feature. It is suggested that this tag be used whenever a secondary identifier for the feature is needed, such as locus names and accession numbers. Unlike ID, there is no requirement that Alias be unique within the file.</dd>
-            <dt>Parent</dt>
+            <dt>[Parent](#parent-(part_of)-relationships)</dt>
             <dd>Indicates the parent of the feature. A parent ID can be used to group exons into transcripts, transcripts into genes, an so forth. A feature may have multiple parents. Parent can <em>only</em> be used to indicate a partof relationship.</dd>
             <dt>Target</dt>
             <dd>Indicates the target of a nucleotide-to-nucleotide or protein-to-nucleotide alignment. The format of the value is "target_id start end [strand]", where strand is optional and may be "+" or "-". If the target_id contains spaces, they must be escaped as hex escape %20.</dd>
-            <dt>Gap</dt>
-            <dd>The alignment of the feature to the target if the two are not collinear (e.g. contain gaps). The alignment format is taken from the CIGAR format described in the <a href="http://cvs.sanger.ac.uk/cgi-bin/viewvc.cgi/exonerate/?root=ensembl">Exonerate documentation</a>. See "THE GAP ATTRIBUTE" for a description of this format.</dd>
+            <dt>[Gap](#the-gap-attribute)</dt>
+            <dd>The alignment of the feature to the target if the two are not collinear (e.g. contain gaps). The alignment format is inspired from the CIGAR format described in the <a href="https://www.ebi.ac.uk/about/vertebrate-genomics/software/exonerate-manual">Exonerate documentation</a>.</dd>
             <dt>Derives_from</dt>
             <dd>Used to disambiguate the relationship between one feature and another when the relationship is a temporal one rather than a purely structural "part of" one. This is needed for polycistronic genes. See "PATHOLOGICAL CASES" for further discussion.</dd>
             <dt>Note</dt>
             <dd>A free text note.</dd>
-            <dt>Dbxref</dt>
+            <dt>[Dbxref](ontology-associations-and-db-cross-references)</dt>
             <dd>A database cross reference. See the section "Ontology Associations and Db Cross References" for details on the format.</dd>
-            <dt>Ontology_term</dt>
+            <dt>[Ontology_term](ontology-associations-and-db-cross-references)</dt>
             <dd>A cross reference to an ontology term. See the section "Ontology Associations and Db Cross References" for details.</dd>
             <dt>Is_circular</dt>
             <dd>A flag to indicate whether a feature is circular. See extended discussion below.</dd>


### PR DESCRIPTION
* Link to exonerate was broken, it is now updated. 
* The "THE GAP ATTRIBUTE" section doesn't exist anymore on the exonerate web page, so I have removed the sentence pointing to it.
* I have added hyperlinks for obvious sections 

